### PR TITLE
loss.py Bugfix

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -36,6 +36,7 @@ class reweighting_revision_loss(nn.Module):
     def forward(self, out, T, correction, target):
         loss = 0.
         out_softmax = F.softmax(out, dim=1)
+        T_result = T + correction
         for i in range(len(target)):
             temp_softmax = out_softmax[i]
             temp = out[i]
@@ -44,8 +45,6 @@ class reweighting_revision_loss(nn.Module):
             temp_target = target[i]
             temp_target = torch.unsqueeze(temp_target, 0)
             pro1 = temp_softmax[:, target[i]]
-            T = T + correction
-            T_result = T
             out_T = torch.matmul(T_result.t(), temp_softmax.t())
             out_T = out_T.t()
             pro2 = out_T[:, target[i]]    


### PR DESCRIPTION
loss.py Bugfix
1.  在原loss.py的第47行（reweighting_revision_loss类的forward函数）存在一个BUG，该行的T = T + correction应该是写在for循环外面，写在for循环里面会导致transition matrix的correction被不断累积，累积的次数等于batch size的大小，进而导致batch size的大小影响到模型的效果。
2.  原loss.py的第48行(T_result = T)是没有意义的，因为python中变量名只是引用，如果想获取T矩阵的一个复制建议采用：T_result = T.copy()
3.  原先官方代码中loss计算方式是基于for循环，挨个计算batch中每个sample所产生的loss，这样做比较低效，建议以后官方代码可以考虑修改成batch操作的方式，这样能提速五倍以上。新的batch操作版的loss我已经实现好了，也放在了loss.py中，命名为reweight_loss_v2和reweighting_revision_loss_v2，可以分别用来替代原有的reweight_loss和reweighting_revision_loss以实现加速效果。